### PR TITLE
removed arglines for surefire dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,9 +419,6 @@
                     <includes>
                         <include>**/*.java</include>
                     </includes>
-                    <argLine>
-                      --illegal-access=permit
-                    </argLine>
                 </configuration>
             </plugin>
 
@@ -478,7 +475,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Custom arglines for surefire overskriver jacoco. Siden vi strengt talt ikke trenger custom argline for surefire har jeg fjernet den